### PR TITLE
Add C API to build an index from streaming Arrow data

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -56,6 +56,16 @@ extension needed — uses the same `librype.so` shared library.
 - Requires `pyarrow` (tested with 23.0.0, Python 3.13)
 - Requires `cargo build --release --lib --features arrow-ffi`
 
+### pyarrow_build_example.py
+
+Demonstrates building a `.ryxdi` index from streaming Arrow data via
+`rype_index_build_from_arrow()`. Mirrors a DuckDB/DuckLake pipeline that stores
+genome sequences as fixed-size chunks (`feature_idx`, `chunk_index`,
+`chunk_data`) plus a small `feature_idx -> bucket_name` mapping.
+
+- `rype_index_build_from_arrow()` — build an index from two Arrow streams
+- Requires `pyarrow` and `cargo build --release --lib --features arrow-ffi`
+
 **These Python examples are NOT part of the regular test suite or build
 dependencies.** They have been manually verified but are not run by `cargo test`.
 

--- a/examples/pyarrow_build_example.py
+++ b/examples/pyarrow_build_example.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Rype PyArrow Index Building Example
+
+Demonstrates building a .ryxdi index from streaming Arrow data via rype's
+`rype_index_build_from_arrow` FFI entry point, using PyArrow's C Data Interface
+and ctypes. This mirrors a DuckDB/DuckLake pipeline that stores genome sequences
+as fixed-size chunks (here ~64 bytes for the demo) keyed by feature_idx, plus a
+small feature -> bucket_name mapping.
+
+This example:
+  1. Loads librype.so via ctypes
+  2. Builds a chunk RecordBatchReader (feature_idx, chunk_index, chunk_data)
+  3. Builds a mapping RecordBatchReader (feature_idx, bucket_name)
+  4. Exports both to ArrowArrayStreams and calls rype_index_build_from_arrow()
+  5. Reports success; the .ryxdi directory can then be used with `rype classify`
+
+Prerequisites:
+  - pyarrow
+  - librype built with Arrow FFI support:
+        cargo build --release --lib --features arrow-ffi
+
+Usage:
+  python examples/pyarrow_build_example.py [output.ryxdi]
+
+NOTE: This example is NOT part of the regular test suite or build dependencies.
+PyArrow is not required to build or test rype. It exists to demonstrate and
+verify the Arrow C Data Interface interop for index building.
+"""
+
+import ctypes
+import os
+import sys
+
+import pyarrow as pa
+
+
+def load_librype():
+    """Load librype.so from target/release, built with --features arrow-ffi."""
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    lib_path = os.path.normpath(
+        os.path.join(script_dir, "..", "target", "release", "librype.so")
+    )
+    if not os.path.exists(lib_path):
+        print(f"ERROR: {lib_path} not found.", file=sys.stderr)
+        print(
+            "Build with: cargo build --release --lib --features arrow-ffi",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    lib = ctypes.CDLL(lib_path)
+
+    # int rype_index_build_from_arrow(
+    #     const char* output_path,
+    #     ArrowArrayStream* chunk_stream,
+    #     ArrowArrayStream* mapping_stream,
+    #     size_t k, size_t w, uint64_t salt, int orient, size_t max_memory_bytes)
+    lib.rype_index_build_from_arrow.argtypes = [
+        ctypes.c_char_p,  # output_path
+        ctypes.c_void_p,  # chunk_stream ptr
+        ctypes.c_void_p,  # mapping_stream ptr
+        ctypes.c_size_t,  # k
+        ctypes.c_size_t,  # w
+        ctypes.c_uint64,  # salt
+        ctypes.c_int,     # orient
+        ctypes.c_size_t,  # max_memory_bytes
+    ]
+    lib.rype_index_build_from_arrow.restype = ctypes.c_int
+
+    lib.rype_get_last_error.argtypes = []
+    lib.rype_get_last_error.restype = ctypes.c_char_p
+
+    return lib
+
+
+# ArrowArrayStream is 5 pointers: get_schema, get_next, get_last_error, release, private_data
+ARROW_ARRAY_STREAM_SIZE = 5 * ctypes.sizeof(ctypes.c_void_p)
+
+
+def alloc_arrow_stream():
+    """Allocate a zeroed ArrowArrayStream buffer, return (buffer, pointer)."""
+    buf = ctypes.create_string_buffer(ARROW_ARRAY_STREAM_SIZE)
+    return buf, ctypes.cast(buf, ctypes.c_void_p).value
+
+
+def chunk_reader(genomes, chunk_size=64):
+    """
+    Build a RecordBatchReader of (feature_idx, chunk_index, chunk_data).
+
+    `genomes` maps feature_idx (int) -> sequence bytes. Each sequence is split
+    into `chunk_size`-byte blocks emitted in ascending, 0-based chunk_index order.
+    A feature's chunks are kept contiguous, as rype requires.
+    """
+    schema = pa.schema(
+        [
+            ("feature_idx", pa.int64()),
+            ("chunk_index", pa.int32()),
+            ("chunk_data", pa.binary()),
+        ]
+    )
+    feats, idxs, datas = [], [], []
+    for fid, seq in genomes.items():
+        for i in range(0, len(seq), chunk_size):
+            feats.append(fid)
+            idxs.append(i // chunk_size)
+            datas.append(seq[i : i + chunk_size])
+    batch = pa.record_batch(
+        [
+            pa.array(feats, type=pa.int64()),
+            pa.array(idxs, type=pa.int32()),
+            pa.array(datas, type=pa.binary()),
+        ],
+        schema=schema,
+    )
+    return pa.RecordBatchReader.from_batches(schema, [batch])
+
+
+def mapping_reader(feature_to_bucket):
+    """Build a RecordBatchReader of (feature_idx, bucket_name)."""
+    schema = pa.schema([("feature_idx", pa.int64()), ("bucket_name", pa.utf8())])
+    batch = pa.record_batch(
+        [
+            pa.array(list(feature_to_bucket.keys()), type=pa.int64()),
+            pa.array(list(feature_to_bucket.values()), type=pa.utf8()),
+        ],
+        schema=schema,
+    )
+    return pa.RecordBatchReader.from_batches(schema, [batch])
+
+
+def build_index(lib, out_path, genomes, feature_to_bucket, k=32, w=50, salt=0x5555555555555555, orient=False):
+    chunk_buf, chunk_ptr = alloc_arrow_stream()
+    map_buf, map_ptr = alloc_arrow_stream()
+
+    # Export both readers into ArrowArrayStreams; rype takes ownership of each.
+    chunk_reader(genomes)._export_to_c(chunk_ptr)
+    mapping_reader(feature_to_bucket)._export_to_c(map_ptr)
+
+    rc = lib.rype_index_build_from_arrow(
+        out_path.encode("utf-8"),
+        chunk_ptr,
+        map_ptr,
+        k,
+        w,
+        salt,
+        1 if orient else 0,
+        0,  # max_memory_bytes = auto
+    )
+    if rc != 0:
+        err = lib.rype_get_last_error()
+        msg = err.decode("utf-8") if err else "unknown error"
+        raise RuntimeError(f"rype index build failed: {msg}")
+
+
+def main():
+    out_path = sys.argv[1] if len(sys.argv) > 1 else "scratch/pyarrow_built.ryxdi"
+    lib = load_librype()
+
+    # Two toy "genomes" (feature_idx -> sequence), and a feature -> bucket mapping.
+    genomes = {
+        1: b"ACGTACGTTGCAACGTGGTTACACGGTACACACGTTTGACACGTGGTACTTACAGGTAACGTACGTACGTTTGCA",
+        2: b"TTGCAACGTGGTTACAGGTACGTACGTACACACGTTTGACACGTGGTACTTACAGGTAACGTACGTACGTGGTTA",
+    }
+    feature_to_bucket = {1: "genome_A", 2: "genome_B"}
+
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    build_index(lib, out_path, genomes, feature_to_bucket, k=32, w=10)
+    print(f"Built index at {out_path}")
+    print("Inspect it with:  rype index stats -i", out_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/rype.h
+++ b/rype.h
@@ -1199,6 +1199,72 @@ struct ArrowArrayStream {
 #endif // ARROW_C_DATA_INTERFACE
 
 // ----------------------------------------------------------------------------
+// Arrow Index Building
+// ----------------------------------------------------------------------------
+
+/**
+ * Build a .ryxdi index from streaming Arrow data.
+ *
+ * Consumes two Arrow streams: a chunk stream of genome sequences split into
+ * ordered blocks (e.g. 64 KB), and a small feature->bucket name mapping. Each
+ * feature's chunks are reassembled (in chunk_index order) before minimizer
+ * extraction, so minimizers are correct across chunk boundaries. Bucket IDs are
+ * assigned internally over the sorted unique bucket names.
+ *
+ * @param output_path      NUL-terminated path to the .ryxdi directory to create
+ * @param chunk_stream     Input ArrowArrayStream of sequence chunks (see schema)
+ * @param mapping_stream   Input ArrowArrayStream of feature->bucket rows
+ * @param k                K-mer size; must be 16, 32, or 64
+ * @param w                Minimizer window size
+ * @param salt             XOR salt for k-mer hashing
+ * @param orient           Non-zero to orient sequences within each bucket
+ * @param max_memory_bytes Memory budget in bytes; 0 = auto-detect
+ * @return                 0 on success, -1 on error (see rype_get_last_error())
+ *
+ * ## Chunk stream schema
+ *
+ * | Column      | Type                              | Description                  |
+ * |-------------|-----------------------------------|------------------------------|
+ * | feature_idx | Int64                             | Genome / read identifier     |
+ * | chunk_index | Int32 or Int64                    | Block order (0-based, ascend)|
+ * | chunk_data  | Binary/LargeBinary/Utf8/LargeUtf8 | Sequence bytes for the block |
+ *
+ * A feature's chunks must arrive contiguously and in ascending, 0-based,
+ * gap-free chunk_index order; violations are reported as errors.
+ *
+ * ## Mapping stream schema
+ *
+ * | Column      | Type   | Description         |
+ * |-------------|--------|---------------------|
+ * | feature_idx | Int64  | Genome / read id    |
+ * | bucket_name | Utf8   | Target bucket label |
+ *
+ * ## Memory Management
+ *
+ * - This function TAKES OWNERSHIP of both chunk_stream and mapping_stream
+ *   (their release callbacks are invoked); do not release or reuse them.
+ *   Exception: if a NULL argument is detected the function returns -1 before
+ *   taking ownership of either stream, so the caller still owns them.
+ *
+ * ## On Error
+ *
+ * The index directory is written incrementally and is NOT atomic. If this
+ * function returns -1 partway through, a partial (manifest-less, unusable)
+ * directory may remain at output_path; discard it. Build into a temporary path
+ * and move it into place on success if atomicity is required.
+ */
+int rype_index_build_from_arrow(
+    const char* output_path,
+    struct ArrowArrayStream* chunk_stream,
+    struct ArrowArrayStream* mapping_stream,
+    size_t k,
+    size_t w,
+    uint64_t salt,
+    int orient,
+    size_t max_memory_bytes
+);
+
+// ----------------------------------------------------------------------------
 // Arrow Classification Functions
 // ----------------------------------------------------------------------------
 

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -2744,10 +2744,8 @@ mod c_api_tests {
         batches: Vec<RecordBatch>,
         schema: arrow::datatypes::SchemaRef,
     ) -> FFI_ArrowArrayStream {
-        let reader = arrow::record_batch::RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema,
-        );
+        let reader =
+            arrow::record_batch::RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
         FFI_ArrowArrayStream::new(Box::new(reader))
     }
 

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -2198,6 +2198,124 @@ mod arrow_ffi {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // Public API: Build an index from streaming Arrow data
+    // -------------------------------------------------------------------------
+
+    /// Build a `.ryxdi` index from two Arrow streams: a chunk stream of genome
+    /// sequences split into ordered blocks, plus a small feature→bucket mapping.
+    ///
+    /// Both streams are **consumed** (the Arrow C release callback is invoked); do
+    /// not release or reuse them after this call.
+    ///
+    /// # Chunk stream schema
+    /// - `feature_idx`: Int64 — genome / read identifier
+    /// - `chunk_index`: Int32 or Int64 — block order within a feature (0-based,
+    ///   contiguous, ascending; a feature's chunks must arrive together)
+    /// - `chunk_data`: Binary/LargeBinary/Utf8/LargeUtf8/BinaryView/Utf8View — bytes
+    ///
+    /// # Mapping stream schema
+    /// - `feature_idx`: Int64
+    /// - `bucket_name`: Utf8/LargeUtf8/Utf8View — target bucket label
+    ///
+    /// # Arguments
+    /// - `output_path`: NUL-terminated path to the `.ryxdi` directory to create
+    /// - `chunk_stream`, `mapping_stream`: Arrow C streams (consumed)
+    /// - `k`: k-mer size — must be 16, 32, or 64
+    /// - `w`: minimizer window size
+    /// - `salt`: hash salt
+    /// - `orient`: non-zero to orient sequences within each bucket
+    /// - `max_memory_bytes`: memory budget; 0 = auto-detect
+    ///
+    /// # Safety
+    /// - `output_path` must be a valid NUL-terminated C string.
+    /// - `chunk_stream` and `mapping_stream` must be valid, non-null pointers to
+    ///   `FFI_ArrowArrayStream`; ownership is taken by this call. (On a NULL-arg
+    ///   error the function returns -1 before taking ownership of either stream.)
+    ///
+    /// # On error
+    /// The output directory is written incrementally and is not atomic; on a -1
+    /// return a partial, manifest-less directory may remain at `output_path` and
+    /// should be discarded.
+    ///
+    /// # Returns
+    /// 0 on success, -1 on error. Call `rype_get_last_error()` for details.
+    #[no_mangle]
+    pub unsafe extern "C" fn rype_index_build_from_arrow(
+        output_path: *const c_char,
+        chunk_stream: *mut FFI_ArrowArrayStream,
+        mapping_stream: *mut FFI_ArrowArrayStream,
+        k: size_t,
+        w: size_t,
+        salt: u64,
+        orient: c_int,
+        max_memory_bytes: size_t,
+    ) -> i32 {
+        if output_path.is_null() {
+            set_last_error("output_path is NULL".to_string());
+            return -1;
+        }
+        if chunk_stream.is_null() {
+            set_last_error("chunk_stream is NULL".to_string());
+            return -1;
+        }
+        if mapping_stream.is_null() {
+            set_last_error("mapping_stream is NULL".to_string());
+            return -1;
+        }
+
+        let path = match CStr::from_ptr(output_path).to_str() {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(format!("Invalid UTF-8 in output_path: {}", e));
+                return -1;
+            }
+        };
+
+        // from_raw takes ownership of each stream (consuming it).
+        let chunk_reader = match ArrowArrayStreamReader::from_raw(chunk_stream) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("Failed to read chunk stream: {}", e));
+                return -1;
+            }
+        };
+        let mapping_reader = match ArrowArrayStreamReader::from_raw(mapping_stream) {
+            Ok(r) => r,
+            Err(e) => {
+                set_last_error(format!("Failed to read mapping stream: {}", e));
+                return -1;
+            }
+        };
+
+        let max_memory = if max_memory_bytes == 0 {
+            None
+        } else {
+            Some(max_memory_bytes)
+        };
+
+        match crate::parquet_index::build_index_from_arrow(
+            std::path::Path::new(path),
+            chunk_reader,
+            mapping_reader,
+            k,
+            w,
+            salt,
+            orient != 0,
+            max_memory,
+            None,
+        ) {
+            Ok(_stats) => {
+                clear_last_error();
+                0
+            }
+            Err(e) => {
+                set_last_error(format!("Index build failed: {}", e));
+                -1
+            }
+        }
+    }
+
     /// Returns the schema for classification result batches as an FFI_ArrowSchema.
     ///
     /// This allows callers to pre-allocate memory or validate expected output format.
@@ -2618,6 +2736,166 @@ pub use arrow_ffi::*;
 #[cfg(test)]
 mod c_api_tests {
     use super::*;
+
+    // ===== Arrow build FFI (Phase 6) =====
+
+    #[cfg(feature = "arrow-ffi")]
+    fn export_stream(
+        batches: Vec<RecordBatch>,
+        schema: arrow::datatypes::SchemaRef,
+    ) -> FFI_ArrowArrayStream {
+        let reader = arrow::record_batch::RecordBatchIterator::new(
+            batches.into_iter().map(Ok),
+            schema,
+        );
+        FFI_ArrowArrayStream::new(Box::new(reader))
+    }
+
+    #[cfg(feature = "arrow-ffi")]
+    #[test]
+    fn test_build_from_arrow_ffi_roundtrip() {
+        use arrow::array::{ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        // A sequence split across two chunks (forces boundary reassembly).
+        let seq: Vec<u8> =
+            b"ACGTACGTTGCAACGTGGTTACACGGTACACACGTTTGACACGTGGTACTTACAGGTAACGTACGT".to_vec();
+        let mid = seq.len() / 2;
+
+        let chunk_schema = Arc::new(Schema::new(vec![
+            Field::new("feature_idx", DataType::Int64, false),
+            Field::new("chunk_index", DataType::Int32, false),
+            Field::new("chunk_data", DataType::Binary, false),
+        ]));
+        let chunk_batch = RecordBatch::try_new(
+            chunk_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64, 1])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![0i32, 1])) as ArrayRef,
+                Arc::new(BinaryArray::from(vec![&seq[..mid], &seq[mid..]])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let map_schema = Arc::new(Schema::new(vec![
+            Field::new("feature_idx", DataType::Int64, false),
+            Field::new("bucket_name", DataType::Utf8, false),
+        ]));
+        let map_batch = RecordBatch::try_new(
+            map_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["g1"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+        let out_c = CString::new(out.to_str().unwrap()).unwrap();
+
+        let mut chunk_stream = export_stream(vec![chunk_batch], chunk_schema);
+        let mut map_stream = export_stream(vec![map_batch], map_schema);
+
+        let rc = unsafe {
+            rype_index_build_from_arrow(
+                out_c.as_ptr(),
+                &mut chunk_stream as *mut _,
+                &mut map_stream as *mut _,
+                k,
+                w,
+                salt,
+                0,
+                64 << 20,
+            )
+        };
+        assert_eq!(rc, 0, "build failed: {}", unsafe {
+            CStr::from_ptr(rype_get_last_error()).to_string_lossy()
+        });
+
+        let idx = crate::ShardedInvertedIndex::open(&out).unwrap();
+        assert_eq!(idx.manifest().k, k);
+        assert_eq!(idx.manifest().w, w);
+        assert!(idx.total_minimizers() > 0);
+    }
+
+    #[cfg(feature = "arrow-ffi")]
+    #[test]
+    fn test_build_from_arrow_ffi_invalid_k() {
+        use arrow::array::{ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        let chunk_schema = Arc::new(Schema::new(vec![
+            Field::new("feature_idx", DataType::Int64, false),
+            Field::new("chunk_index", DataType::Int32, false),
+            Field::new("chunk_data", DataType::Binary, false),
+        ]));
+        let chunk_batch = RecordBatch::try_new(
+            chunk_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![0i32])) as ArrayRef,
+                Arc::new(BinaryArray::from(vec![b"ACGTACGTACGTACGT".as_ref()])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+        let map_schema = Arc::new(Schema::new(vec![
+            Field::new("feature_idx", DataType::Int64, false),
+            Field::new("bucket_name", DataType::Utf8, false),
+        ]));
+        let map_batch = RecordBatch::try_new(
+            map_schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1i64])) as ArrayRef,
+                Arc::new(StringArray::from(vec!["g1"])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let out_c = CString::new(dir.path().join("idx.ryxdi").to_str().unwrap()).unwrap();
+        let mut chunk_stream = export_stream(vec![chunk_batch], chunk_schema);
+        let mut map_stream = export_stream(vec![map_batch], map_schema);
+
+        let rc = unsafe {
+            rype_index_build_from_arrow(
+                out_c.as_ptr(),
+                &mut chunk_stream as *mut _,
+                &mut map_stream as *mut _,
+                20, // invalid k
+                5,
+                0,
+                0,
+                64 << 20,
+            )
+        };
+        assert_eq!(rc, -1);
+        let msg = unsafe { CStr::from_ptr(rype_get_last_error()).to_string_lossy() };
+        assert!(msg.contains("16, 32, or 64"), "{msg}");
+    }
+
+    #[cfg(feature = "arrow-ffi")]
+    #[test]
+    fn test_build_from_arrow_ffi_null_args() {
+        let rc = unsafe {
+            rype_index_build_from_arrow(
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                16,
+                5,
+                0,
+                0,
+                0,
+            )
+        };
+        assert_eq!(rc, -1);
+        let msg = unsafe { CStr::from_ptr(rype_get_last_error()).to_string_lossy() };
+        assert!(msg.contains("output_path is NULL"), "{msg}");
+    }
 
     #[test]
     fn test_validate_query_null_seq() {

--- a/src/indices/parquet/arrow_build.rs
+++ b/src/indices/parquet/arrow_build.rs
@@ -169,8 +169,7 @@ fn build_index_from_arrow_inner(
     let mut pending_bytes: usize = 0;
 
     for batch in chunks {
-        let batch =
-            batch.map_err(|e| RypeError::validation(format!("chunk stream error: {e}")))?;
+        let batch = batch.map_err(|e| RypeError::validation(format!("chunk stream error: {e}")))?;
         for (fid, seq) in reasm.push_batch(&batch)? {
             pending_bytes += seq.len();
             pending.push((fid, seq));
@@ -232,7 +231,12 @@ fn build_index_from_arrow_inner(
     } else {
         Some(&file_stats)
     };
-    write_buckets_parquet(output_dir, &bmap.bucket_names, &bucket_sources, file_stats_opt)?;
+    write_buckets_parquet(
+        output_dir,
+        &bmap.bucket_names,
+        &bucket_sources,
+        file_stats_opt,
+    )?;
 
     let source_hash = compute_source_hash(&bucket_min_counts);
     let num_buckets = bmap.num_buckets();
@@ -285,10 +289,11 @@ fn write_feature_minimizers(
     // there is no file in this data model, so the path-part is the literal "feature_idx"
     // and the seq-part is the integer id, e.g. "feature_idx::12345". This keeps
     // `index bucket-source-detail` (which splits on the delimiter) well-formed.
-    bucket_sources
-        .entry(bucket_id)
-        .or_default()
-        .push(format!("feature_idx{}{}", crate::BUCKET_SOURCE_DELIM, fid));
+    bucket_sources.entry(bucket_id).or_default().push(format!(
+        "feature_idx{}{}",
+        crate::BUCKET_SOURCE_DELIM,
+        fid
+    ));
     bucket_file_lengths
         .entry(bucket_id)
         .or_default()
@@ -534,10 +539,9 @@ impl<'a> IndexColumn<'a> {
 
 /// Look up a required column index by name.
 fn column_index(batch: &RecordBatch, name: &str) -> RypeResult<usize> {
-    batch
-        .schema()
-        .index_of(name)
-        .map_err(|_| RypeError::validation(format!("chunk batch missing required column '{}'", name)))
+    batch.schema().index_of(name).map_err(|_| {
+        RypeError::validation(format!("chunk batch missing required column '{}'", name))
+    })
 }
 
 /// Decode the three chunk columns from a batch into typed accessors.
@@ -852,7 +856,8 @@ mod tests {
     fn chunk_batch(rows: &[(i64, i32, &[u8])]) -> RecordBatch {
         let features: Int64Array = rows.iter().map(|(f, _, _)| *f).collect();
         let indices: Int32Array = rows.iter().map(|(_, c, _)| *c).collect();
-        let data: BinaryArray = BinaryArray::from(rows.iter().map(|(_, _, d)| *d).collect::<Vec<_>>());
+        let data: BinaryArray =
+            BinaryArray::from(rows.iter().map(|(_, _, d)| *d).collect::<Vec<_>>());
         let schema = Schema::new(vec![
             Field::new(COL_FEATURE_IDX, DataType::Int64, false),
             Field::new(COL_CHUNK_INDEX, DataType::Int32, false),
@@ -889,7 +894,10 @@ mod tests {
             (2, 0, b"GGGG"),
         ]);
         let out = reassemble(&[batch]).unwrap();
-        assert_eq!(out, vec![(1, b"ACGTTTGGCC".to_vec()), (2, b"GGGG".to_vec())]);
+        assert_eq!(
+            out,
+            vec![(1, b"ACGTTTGGCC".to_vec()), (2, b"GGGG".to_vec())]
+        );
     }
 
     #[test]
@@ -897,7 +905,10 @@ mod tests {
         let b1 = chunk_batch(&[(7, 0, b"AAAA"), (7, 1, b"CCCC")]);
         let b2 = chunk_batch(&[(7, 2, b"GGGG"), (8, 0, b"TTTT")]);
         let out = reassemble(&[b1, b2]).unwrap();
-        assert_eq!(out, vec![(7, b"AAAACCCCGGGG".to_vec()), (8, b"TTTT".to_vec())]);
+        assert_eq!(
+            out,
+            vec![(7, b"AAAACCCCGGGG".to_vec()), (8, b"TTTT".to_vec())]
+        );
     }
 
     #[test]
@@ -919,7 +930,10 @@ mod tests {
     fn rejects_nonzero_first_chunk() {
         let batch = chunk_batch(&[(1, 1, b"AC")]);
         let err = reassemble(&[batch]).unwrap_err();
-        assert!(err.to_string().contains("first chunk_index must be 0"), "{err}");
+        assert!(
+            err.to_string().contains("first chunk_index must be 0"),
+            "{err}"
+        );
     }
 
     #[test]
@@ -967,8 +981,12 @@ mod tests {
     #[test]
     fn assigns_deterministic_ids_over_sorted_names() {
         // Two distinct names; "alpha" sorts before "zeta" → alpha=1, zeta=2.
-        let m = bucket_map(vec![mapping_batch(&[(10, "zeta"), (20, "alpha"), (30, "alpha")])])
-            .unwrap();
+        let m = bucket_map(vec![mapping_batch(&[
+            (10, "zeta"),
+            (20, "alpha"),
+            (30, "alpha"),
+        ])])
+        .unwrap();
         assert_eq!(m.num_buckets(), 2);
         let alpha = m.bucket_of(20).unwrap();
         let zeta = m.bucket_of(10).unwrap();
@@ -1015,7 +1033,10 @@ mod tests {
         assert!(!m.mark_feature_done(a), "first of two should not complete");
         assert!(m.mark_feature_done(a), "second of two should complete");
         // bucket b has 1 feature.
-        assert!(m.mark_feature_done(b), "single feature completes immediately");
+        assert!(
+            m.mark_feature_done(b),
+            "single feature completes immediately"
+        );
     }
 
     #[test]
@@ -1210,12 +1231,17 @@ mod tests {
         )
         .unwrap();
 
-        let (_names, sources, _stats) =
-            crate::parquet_index::read_buckets_parquet(&out).unwrap();
+        let (_names, sources, _stats) = crate::parquet_index::read_buckets_parquet(&out).unwrap();
         let bucket_sources = sources.values().next().unwrap();
         let mut got: Vec<&String> = bucket_sources.iter().collect();
         got.sort();
-        assert_eq!(got, vec![&"feature_idx::10".to_string(), &"feature_idx::20".to_string()]);
+        assert_eq!(
+            got,
+            vec![
+                &"feature_idx::10".to_string(),
+                &"feature_idx::20".to_string()
+            ]
+        );
     }
 
     #[test]
@@ -1267,7 +1293,10 @@ mod tests {
         )
         .unwrap();
         let got_on = load_all_minimizers(&ShardedInvertedIndex::open(&out_on).unwrap()).unwrap();
-        assert_eq!(got_on, want, "orientation should flip RC feature back to baseline");
+        assert_eq!(
+            got_on, want,
+            "orientation should flip RC feature back to baseline"
+        );
 
         let out_off = dir.path().join("off.ryxdi");
         build(
@@ -1321,7 +1350,10 @@ mod tests {
         )
         .unwrap();
         let got = load_all_minimizers(&ShardedInvertedIndex::open(&out).unwrap()).unwrap();
-        assert_eq!(got, want, "interleaved orientation must keep g1's baseline live for f3");
+        assert_eq!(
+            got, want,
+            "interleaved orientation must keep g1's baseline live for f3"
+        );
     }
 
     #[test]

--- a/src/indices/parquet/arrow_build.rs
+++ b/src/indices/parquet/arrow_build.rs
@@ -1,0 +1,1381 @@
+//! Build a Parquet inverted index from streaming Arrow data.
+//!
+//! This is the engine behind the C/FFI `rype_index_build_from_arrow` entry point.
+//! It consumes chunked genome sequences delivered over Arrow (a DuckDB/DuckLake
+//! pipeline that splits each genome into ordered ~64 KB blocks) plus a small
+//! feature→bucket mapping, and produces a `.ryxdi` directory.
+//!
+//! # Input schema
+//!
+//! **Chunk stream** — one row per ~64 KB block, a feature's chunks delivered
+//! contiguously in ascending `chunk_index`:
+//!
+//! | Column        | Type                              | Description                  |
+//! |---------------|-----------------------------------|------------------------------|
+//! | `feature_idx` | `Int64`                           | Genome / read identifier     |
+//! | `chunk_index` | `Int32`                           | Block order within a feature |
+//! | `chunk_data`  | `Binary`/`LargeBinary`/`Utf8`/... | Sequence bytes for the block |
+//!
+//! **Mapping stream** — small, one row per feature:
+//!
+//! | Column        | Type    | Description          |
+//! |---------------|---------|----------------------|
+//! | `feature_idx` | `Int64` | Genome / read id     |
+//! | `bucket_name` | `Utf8`  | Target bucket label  |
+//!
+//! Bucket IDs are assigned internally (1..N over the sorted, sanitized unique
+//! bucket names); callers neither supply nor observe them.
+//!
+//! # Why reassemble
+//!
+//! Minimizers slide over a `w + k - 1` window, so a window can straddle a chunk
+//! boundary. Each feature's chunks are therefore reassembled (in verified
+//! `chunk_index` order) into the full sequence before extraction — this is correct
+//! across boundaries and is also required for orientation, which is a whole-sequence,
+//! per-bucket decision.
+
+use std::path::Path;
+
+use arrow::array::{
+    Array, BinaryArray, BinaryViewArray, Int32Array, Int64Array, LargeBinaryArray,
+    LargeStringArray, StringArray, StringViewArray,
+};
+use arrow::error::ArrowError;
+use arrow::record_batch::RecordBatch;
+
+use crate::error::{Result as RypeResult, RypeError};
+use crate::parquet_index::ParquetWriteOptions;
+use crate::{
+    choose_orientation_sampled, extract_dual_strand_into, extract_into, MinimizerWorkspace,
+    Orientation,
+};
+
+/// Column names of the chunk stream.
+const COL_FEATURE_IDX: &str = "feature_idx";
+const COL_CHUNK_INDEX: &str = "chunk_index";
+const COL_CHUNK_DATA: &str = "chunk_data";
+
+/// The first `chunk_index` expected for every feature. Chunks must be contiguous
+/// and 0-based; the reassembler fails loud on any deviation.
+const FIRST_CHUNK_INDEX: i64 = 0;
+
+/// Summary of a completed Arrow build, returned to callers for reporting/testing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArrowBuildStats {
+    /// Number of buckets written.
+    pub num_buckets: u32,
+    /// Number of distinct features processed from the chunk stream.
+    pub num_features: u64,
+    /// Total minimizers written (may include duplicates across shards).
+    pub total_minimizers: u64,
+    /// Number of shards written.
+    pub num_shards: u32,
+}
+
+/// Build a `.ryxdi` index from streaming Arrow chunk + mapping readers.
+///
+/// `chunks` yields `RecordBatch`es with `feature_idx`/`chunk_index`/`chunk_data`
+/// columns; `mapping` yields `feature_idx`/`bucket_name` rows and is consumed in
+/// full up front. Both are plain iterators so the builder is testable without the
+/// `arrow-ffi` C-stream machinery.
+///
+/// `max_memory` of `None` auto-detects the available budget.
+#[allow(clippy::too_many_arguments)]
+pub fn build_index_from_arrow(
+    output_dir: &Path,
+    chunks: impl Iterator<Item = Result<RecordBatch, ArrowError>>,
+    mapping: impl Iterator<Item = Result<RecordBatch, ArrowError>>,
+    k: usize,
+    w: usize,
+    salt: u64,
+    orient: bool,
+    max_memory: Option<usize>,
+    options: Option<&ParquetWriteOptions>,
+) -> RypeResult<ArrowBuildStats> {
+    use crate::memory::detect_available_memory;
+
+    let available = max_memory.unwrap_or_else(|| detect_available_memory().bytes);
+    // Completed features are buffered up to this many bytes, then extracted in
+    // parallel. Bounds the transient feature buffer to ~an eighth of the budget.
+    let batch_target_bytes = (available / 8).max(8 * 1024 * 1024);
+    build_index_from_arrow_inner(
+        output_dir,
+        chunks,
+        mapping,
+        k,
+        w,
+        salt,
+        orient,
+        available,
+        batch_target_bytes,
+        options,
+    )
+}
+
+/// Inner builder with an explicit `batch_target_bytes` seam so tests can force tiny
+/// batches (one feature each) and assert batch-size invariance.
+#[allow(clippy::too_many_arguments)]
+fn build_index_from_arrow_inner(
+    output_dir: &Path,
+    chunks: impl Iterator<Item = Result<RecordBatch, ArrowError>>,
+    mapping: impl Iterator<Item = Result<RecordBatch, ArrowError>>,
+    k: usize,
+    w: usize,
+    salt: u64,
+    orient: bool,
+    available: usize,
+    batch_target_bytes: usize,
+    options: Option<&ParquetWriteOptions>,
+) -> RypeResult<ArrowBuildStats> {
+    use crate::parquet_index::{
+        compute_source_hash, create_index_directory, write_buckets_parquet, InvertedManifest,
+        ParquetManifest, ParquetShardFormat, ShardAccumulator, FORMAT_MAGIC, FORMAT_VERSION,
+        MIN_SHARD_BYTES,
+    };
+    use crate::BucketFileStats;
+    use std::collections::HashMap;
+
+    if !matches!(k, 16 | 32 | 64) {
+        return Err(RypeError::validation(format!(
+            "k must be 16, 32, or 64; got {k}"
+        )));
+    }
+    // Resolve the whole feature→bucket mapping before touching the chunk stream.
+    let mut bmap = BucketMap::from_reader(mapping)?;
+
+    create_index_directory(output_dir)?;
+
+    // Half the memory budget per shard, clamped to the minimum shard size; entries
+    // are added in batches of roughly one shard's worth (capped) before flushing.
+    let shard_size = (available / 2).max(MIN_SHARD_BYTES);
+    let add_batch_entries = (shard_size / ShardAccumulator::BYTES_PER_ENTRY).clamp(1, 8_000_000);
+
+    let opts = options.cloned().unwrap_or_default();
+    let mut acc = ShardAccumulator::with_output_dir(output_dir, shard_size, Some(&opts));
+
+    // Per-bucket metadata accumulated for the manifest + buckets.parquet.
+    let mut bucket_sources: HashMap<u32, Vec<String>> = HashMap::new();
+    let mut bucket_min_counts: HashMap<u32, usize> = HashMap::new();
+    let mut bucket_file_lengths: HashMap<u32, Vec<u64>> = HashMap::new();
+    let mut total_minimizers: u64 = 0;
+    let mut num_features: u64 = 0;
+    // bucket id → fixed orientation baseline (sorted, deduped minimizers from the
+    // bucket's first feature). Dropped as soon as the bucket's last feature is done.
+    let mut baselines: HashMap<u32, Vec<u64>> = HashMap::new();
+
+    let mut reasm = FeatureReassembler::new();
+    // Completed features buffered for the next parallel extraction batch.
+    let mut pending: Vec<(i64, Vec<u8>)> = Vec::new();
+    let mut pending_bytes: usize = 0;
+
+    for batch in chunks {
+        let batch =
+            batch.map_err(|e| RypeError::validation(format!("chunk stream error: {e}")))?;
+        for (fid, seq) in reasm.push_batch(&batch)? {
+            pending_bytes += seq.len();
+            pending.push((fid, seq));
+            if pending_bytes >= batch_target_bytes {
+                num_features += pending.len() as u64;
+                flush_feature_batch(
+                    &mut pending,
+                    &mut bmap,
+                    &mut baselines,
+                    orient,
+                    k,
+                    w,
+                    salt,
+                    add_batch_entries,
+                    &mut acc,
+                    &mut bucket_sources,
+                    &mut bucket_min_counts,
+                    &mut bucket_file_lengths,
+                    &mut total_minimizers,
+                )?;
+                pending_bytes = 0;
+            }
+        }
+    }
+    if let Some((fid, seq)) = reasm.finish() {
+        pending.push((fid, seq));
+    }
+    if !pending.is_empty() {
+        num_features += pending.len() as u64;
+        flush_feature_batch(
+            &mut pending,
+            &mut bmap,
+            &mut baselines,
+            orient,
+            k,
+            w,
+            salt,
+            add_batch_entries,
+            &mut acc,
+            &mut bucket_sources,
+            &mut bucket_min_counts,
+            &mut bucket_file_lengths,
+            &mut total_minimizers,
+        )?;
+    }
+
+    // Finalize: mirror the multi-bucket streaming tail (no consolidation; shards may
+    // overlap in minimizer range across buckets → has_overlapping_shards: true).
+    let shard_infos = acc.finish()?;
+    let num_shards = shard_infos.len() as u32;
+    let total_entries: u64 = shard_infos.iter().map(|s| s.num_entries).sum();
+
+    let file_stats: HashMap<u32, BucketFileStats> = bucket_file_lengths
+        .iter()
+        .filter_map(|(id, lens)| BucketFileStats::from_file_lengths(lens).map(|s| (*id, s)))
+        .collect();
+    let file_stats_opt = if file_stats.is_empty() {
+        None
+    } else {
+        Some(&file_stats)
+    };
+    write_buckets_parquet(output_dir, &bmap.bucket_names, &bucket_sources, file_stats_opt)?;
+
+    let source_hash = compute_source_hash(&bucket_min_counts);
+    let num_buckets = bmap.num_buckets();
+
+    let manifest = ParquetManifest {
+        magic: FORMAT_MAGIC.to_string(),
+        format_version: FORMAT_VERSION,
+        k,
+        w,
+        salt,
+        source_hash,
+        num_buckets,
+        total_minimizers,
+        inverted: Some(InvertedManifest {
+            format: ParquetShardFormat::Parquet,
+            num_shards,
+            total_entries,
+            has_overlapping_shards: true,
+            shards: shard_infos,
+        }),
+    };
+    manifest.save(output_dir)?;
+
+    Ok(ArrowBuildStats {
+        num_buckets,
+        num_features,
+        total_minimizers,
+        num_shards,
+    })
+}
+
+/// Record one feature's chosen-strand minimizers: update per-bucket metadata and
+/// stream the (minimizer, bucket_id) entries into the accumulator.
+#[allow(clippy::too_many_arguments)]
+fn write_feature_minimizers(
+    bucket_id: u32,
+    fid: i64,
+    seq_len: usize,
+    mins: &[u64],
+    add_batch_entries: usize,
+    acc: &mut crate::parquet_index::ShardAccumulator,
+    bucket_sources: &mut std::collections::HashMap<u32, Vec<String>>,
+    bucket_min_counts: &mut std::collections::HashMap<u32, usize>,
+    bucket_file_lengths: &mut std::collections::HashMap<u32, Vec<u64>>,
+    total_minimizers: &mut u64,
+) -> RypeResult<()> {
+    *total_minimizers += mins.len() as u64;
+    *bucket_min_counts.entry(bucket_id).or_insert(0) += mins.len();
+    // Source label uses the established two-part `path::seqname` form (BUCKET_SOURCE_DELIM):
+    // there is no file in this data model, so the path-part is the literal "feature_idx"
+    // and the seq-part is the integer id, e.g. "feature_idx::12345". This keeps
+    // `index bucket-source-detail` (which splits on the delimiter) well-formed.
+    bucket_sources
+        .entry(bucket_id)
+        .or_default()
+        .push(format!("feature_idx{}{}", crate::BUCKET_SOURCE_DELIM, fid));
+    bucket_file_lengths
+        .entry(bucket_id)
+        .or_default()
+        .push(seq_len as u64);
+
+    for chunk in mins.chunks(add_batch_entries) {
+        acc.add_entries_from_minimizers(chunk, bucket_id);
+        while acc.should_flush() {
+            acc.flush_shard()?;
+        }
+    }
+    Ok(())
+}
+
+/// Extract a byte-bounded batch of completed features in parallel and stream their
+/// minimizers into the accumulator, draining `pending`.
+///
+/// The minimizer SET and per-feature orientation decisions are independent of how
+/// features are grouped into batches: a bucket's baseline is always seeded by its
+/// globally-first feature (in stream order), and orientation depends only on that
+/// fixed baseline. Only minimizer *extraction* is parallel; accumulator writes and
+/// completion bookkeeping stay serial (the accumulator is not thread-safe).
+#[allow(clippy::too_many_arguments)]
+fn flush_feature_batch(
+    pending: &mut Vec<(i64, Vec<u8>)>,
+    bmap: &mut BucketMap,
+    baselines: &mut std::collections::HashMap<u32, Vec<u64>>,
+    orient: bool,
+    k: usize,
+    w: usize,
+    salt: u64,
+    add_batch_entries: usize,
+    acc: &mut crate::parquet_index::ShardAccumulator,
+    bucket_sources: &mut std::collections::HashMap<u32, Vec<String>>,
+    bucket_min_counts: &mut std::collections::HashMap<u32, usize>,
+    bucket_file_lengths: &mut std::collections::HashMap<u32, Vec<u64>>,
+    total_minimizers: &mut u64,
+) -> RypeResult<()> {
+    use rayon::prelude::*;
+    use std::collections::HashSet;
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    // 1. Resolve each feature's bucket (serial; surfaces unmapped-feature errors). In
+    //    orient mode, the first feature of a bucket lacking a baseline is a SEED; every
+    //    other feature orients against a baseline guaranteed to exist by the orient pass.
+    let mut seeds: Vec<(i64, u32, Vec<u8>)> = Vec::new();
+    let mut others: Vec<(i64, u32, Vec<u8>)> = Vec::new();
+    let mut seeded_this_batch: HashSet<u32> = HashSet::new();
+    for (fid, seq) in pending.drain(..) {
+        let bid = bmap.bucket_of(fid)?;
+        if orient && !baselines.contains_key(&bid) && !seeded_this_batch.contains(&bid) {
+            seeded_this_batch.insert(bid);
+            seeds.push((fid, bid, seq));
+        } else {
+            others.push((fid, bid, seq));
+        }
+    }
+
+    // 2. Extract seed baselines in parallel (distinct, independent buckets), then
+    //    install each and write its forward minimizers.
+    let seed_mins: Vec<(i64, u32, usize, Vec<u64>)> = seeds
+        .par_iter()
+        .map_init(MinimizerWorkspace::new, |ws, (fid, bid, seq)| {
+            extract_into(seq, k, w, salt, ws);
+            ws.buffer.sort_unstable();
+            ws.buffer.dedup();
+            (*fid, *bid, seq.len(), ws.buffer.clone())
+        })
+        .collect();
+    let mut batch_bids: Vec<u32> = Vec::with_capacity(seed_mins.len() + others.len());
+    for (fid, bid, len, mins) in seed_mins {
+        baselines.insert(bid, mins);
+        write_feature_minimizers(
+            bid,
+            fid,
+            len,
+            &baselines[&bid],
+            add_batch_entries,
+            acc,
+            bucket_sources,
+            bucket_min_counts,
+            bucket_file_lengths,
+            total_minimizers,
+        )?;
+        batch_bids.push(bid);
+    }
+
+    // 3. Extract the remaining features in parallel. For orient, decide the strand
+    //    against the now-complete baselines (read-only); otherwise take forward.
+    let baselines_ref: &std::collections::HashMap<u32, Vec<u64>> = baselines;
+    let other_mins: Vec<(i64, u32, usize, Vec<u64>)> = others
+        .par_iter()
+        .map_init(MinimizerWorkspace::new, |ws, (fid, bid, seq)| {
+            if orient {
+                let (mut fwd, mut rc) = extract_dual_strand_into(seq, k, w, salt, ws);
+                fwd.sort_unstable();
+                rc.sort_unstable();
+                let baseline = baselines_ref
+                    .get(bid)
+                    .expect("baseline is seeded before the orient pass");
+                let (orientation, _overlap) = choose_orientation_sampled(baseline, &fwd, &rc);
+                let mut chosen = match orientation {
+                    Orientation::Forward => fwd,
+                    Orientation::ReverseComplement => rc,
+                };
+                chosen.dedup();
+                (*fid, *bid, seq.len(), chosen)
+            } else {
+                extract_into(seq, k, w, salt, ws);
+                ws.buffer.sort_unstable();
+                ws.buffer.dedup();
+                (*fid, *bid, seq.len(), ws.buffer.clone())
+            }
+        })
+        .collect();
+    for (fid, bid, len, mins) in &other_mins {
+        write_feature_minimizers(
+            *bid,
+            *fid,
+            *len,
+            mins,
+            add_batch_entries,
+            acc,
+            bucket_sources,
+            bucket_min_counts,
+            bucket_file_lengths,
+            total_minimizers,
+        )?;
+        batch_bids.push(*bid);
+    }
+
+    // 4. Mark each processed feature done; free a bucket's baseline once complete.
+    //    Extraction has finished, so freeing a completed bucket here is safe.
+    for bid in batch_bids {
+        if bmap.mark_feature_done(bid) {
+            baselines.remove(&bid);
+        }
+    }
+    Ok(())
+}
+
+/// Uniform read access to a binary/string Arrow column. Bytes are copied into the
+/// reassembly buffer, so there is no zero-copy lifetime to preserve here.
+enum BytesColumn<'a> {
+    Binary(&'a BinaryArray),
+    LargeBinary(&'a LargeBinaryArray),
+    String(&'a StringArray),
+    LargeString(&'a LargeStringArray),
+    BinaryView(&'a BinaryViewArray),
+    StringView(&'a StringViewArray),
+}
+
+impl<'a> BytesColumn<'a> {
+    fn from_column(batch: &'a RecordBatch, idx: usize, name: &str) -> RypeResult<Self> {
+        let column = batch.column(idx);
+        if let Some(a) = column.as_any().downcast_ref::<BinaryArray>() {
+            Ok(BytesColumn::Binary(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<LargeBinaryArray>() {
+            Ok(BytesColumn::LargeBinary(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<StringArray>() {
+            Ok(BytesColumn::String(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<LargeStringArray>() {
+            Ok(BytesColumn::LargeString(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<BinaryViewArray>() {
+            Ok(BytesColumn::BinaryView(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<StringViewArray>() {
+            Ok(BytesColumn::StringView(a))
+        } else {
+            Err(RypeError::validation(format!(
+                "column '{}' must be Binary/LargeBinary/Utf8/LargeUtf8/BinaryView/Utf8View, got {:?}",
+                name,
+                column.data_type()
+            )))
+        }
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        match self {
+            BytesColumn::Binary(a) => a.is_null(i),
+            BytesColumn::LargeBinary(a) => a.is_null(i),
+            BytesColumn::String(a) => a.is_null(i),
+            BytesColumn::LargeString(a) => a.is_null(i),
+            BytesColumn::BinaryView(a) => a.is_null(i),
+            BytesColumn::StringView(a) => a.is_null(i),
+        }
+    }
+
+    #[inline]
+    fn value(&self, i: usize) -> &[u8] {
+        match self {
+            BytesColumn::Binary(a) => a.value(i),
+            BytesColumn::LargeBinary(a) => a.value(i),
+            BytesColumn::String(a) => a.value(i).as_bytes(),
+            BytesColumn::LargeString(a) => a.value(i).as_bytes(),
+            BytesColumn::BinaryView(a) => a.value(i),
+            BytesColumn::StringView(a) => a.value(i).as_bytes(),
+        }
+    }
+}
+
+/// A `chunk_index` column, normalized to `i64` regardless of Int32/Int64 width.
+enum IndexColumn<'a> {
+    I32(&'a Int32Array),
+    I64(&'a Int64Array),
+}
+
+impl<'a> IndexColumn<'a> {
+    fn from_column(batch: &'a RecordBatch, idx: usize, name: &str) -> RypeResult<Self> {
+        let column = batch.column(idx);
+        if let Some(a) = column.as_any().downcast_ref::<Int32Array>() {
+            Ok(IndexColumn::I32(a))
+        } else if let Some(a) = column.as_any().downcast_ref::<Int64Array>() {
+            Ok(IndexColumn::I64(a))
+        } else {
+            Err(RypeError::validation(format!(
+                "column '{}' must be Int32 or Int64, got {:?}",
+                name,
+                column.data_type()
+            )))
+        }
+    }
+
+    #[inline]
+    fn is_null(&self, i: usize) -> bool {
+        match self {
+            IndexColumn::I32(a) => a.is_null(i),
+            IndexColumn::I64(a) => a.is_null(i),
+        }
+    }
+
+    #[inline]
+    fn value(&self, i: usize) -> i64 {
+        match self {
+            IndexColumn::I32(a) => a.value(i) as i64,
+            IndexColumn::I64(a) => a.value(i),
+        }
+    }
+}
+
+/// Look up a required column index by name.
+fn column_index(batch: &RecordBatch, name: &str) -> RypeResult<usize> {
+    batch
+        .schema()
+        .index_of(name)
+        .map_err(|_| RypeError::validation(format!("chunk batch missing required column '{}'", name)))
+}
+
+/// Decode the three chunk columns from a batch into typed accessors.
+fn decode_chunk_batch<'a>(
+    batch: &'a RecordBatch,
+) -> RypeResult<(&'a Int64Array, IndexColumn<'a>, BytesColumn<'a>)> {
+    let f_idx = column_index(batch, COL_FEATURE_IDX)?;
+    let c_idx = column_index(batch, COL_CHUNK_INDEX)?;
+    let d_idx = column_index(batch, COL_CHUNK_DATA)?;
+
+    let feature = batch
+        .column(f_idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| {
+            RypeError::validation(format!(
+                "column '{}' must be Int64, got {:?}",
+                COL_FEATURE_IDX,
+                batch.column(f_idx).data_type()
+            ))
+        })?;
+    let chunk_index = IndexColumn::from_column(batch, c_idx, COL_CHUNK_INDEX)?;
+    let chunk_data = BytesColumn::from_column(batch, d_idx, COL_CHUNK_DATA)?;
+    Ok((feature, chunk_index, chunk_data))
+}
+
+// ============================================================================
+// Per-feature reassembly
+// ============================================================================
+
+/// Reassembles complete per-feature sequences from ordered chunk rows.
+///
+/// Chunks for a feature are expected to arrive contiguously, 0-based, in ascending
+/// `chunk_index`. Any gap, duplicate, regression, or a feature reappearing after it
+/// has been closed is a hard error (Rule 10): silently mis-ordered chunks would
+/// corrupt the genome and the resulting minimizers.
+struct FeatureReassembler {
+    current_feature: Option<i64>,
+    /// Next `chunk_index` expected for the in-progress feature.
+    expected_next: i64,
+    /// Accumulated bytes for the in-progress feature.
+    buffer: Vec<u8>,
+    /// Features already emitted, to detect illegal reappearance.
+    closed: std::collections::HashSet<i64>,
+}
+
+impl FeatureReassembler {
+    fn new() -> Self {
+        Self {
+            current_feature: None,
+            expected_next: FIRST_CHUNK_INDEX,
+            buffer: Vec::new(),
+            closed: std::collections::HashSet::new(),
+        }
+    }
+
+    /// Feed one decoded chunk batch, returning every feature that completed within it
+    /// (in stream order). The trailing in-progress feature is held until the next
+    /// batch or [`finish`](Self::finish).
+    fn push_batch(&mut self, batch: &RecordBatch) -> RypeResult<Vec<(i64, Vec<u8>)>> {
+        let (feature, chunk_index, chunk_data) = decode_chunk_batch(batch)?;
+        let mut completed = Vec::new();
+        for i in 0..batch.num_rows() {
+            if feature.is_null(i) {
+                return Err(RypeError::validation(format!(
+                    "null '{}' at chunk row {}",
+                    COL_FEATURE_IDX, i
+                )));
+            }
+            if chunk_index.is_null(i) {
+                return Err(RypeError::validation(format!(
+                    "null '{}' at chunk row {}",
+                    COL_CHUNK_INDEX, i
+                )));
+            }
+            if chunk_data.is_null(i) {
+                return Err(RypeError::validation(format!(
+                    "null '{}' at chunk row {}",
+                    COL_CHUNK_DATA, i
+                )));
+            }
+            let fid = feature.value(i);
+            let cidx = chunk_index.value(i);
+            let data = chunk_data.value(i);
+
+            if self.current_feature == Some(fid) {
+                // Continuation of the in-progress feature.
+                if cidx != self.expected_next {
+                    return Err(RypeError::validation(format!(
+                        "feature {}: expected chunk_index {} but got {} (chunks must be \
+                         contiguous and ascending)",
+                        fid, self.expected_next, cidx
+                    )));
+                }
+                self.buffer.extend_from_slice(data);
+                self.expected_next += 1;
+            } else {
+                // Feature boundary: close the previous, open this one.
+                if let Some(done) = self.close_current() {
+                    completed.push(done);
+                }
+                if !self.closed.insert(fid) {
+                    return Err(RypeError::validation(format!(
+                        "feature {} reappeared after its chunks were already closed; a \
+                         feature's chunks must be delivered contiguously",
+                        fid
+                    )));
+                }
+                if cidx != FIRST_CHUNK_INDEX {
+                    return Err(RypeError::validation(format!(
+                        "feature {}: first chunk_index must be {} but got {}",
+                        fid, FIRST_CHUNK_INDEX, cidx
+                    )));
+                }
+                // `close_current()` above already emptied `buffer` via mem::take
+                // (and on the very first feature it starts empty), so no clear needed.
+                self.current_feature = Some(fid);
+                self.buffer.extend_from_slice(data);
+                self.expected_next = FIRST_CHUNK_INDEX + 1;
+            }
+        }
+        Ok(completed)
+    }
+
+    /// Emit the trailing in-progress feature, if any.
+    fn finish(&mut self) -> Option<(i64, Vec<u8>)> {
+        self.close_current()
+    }
+
+    /// Take the in-progress feature's bytes and reset for the next one.
+    fn close_current(&mut self) -> Option<(i64, Vec<u8>)> {
+        let fid = self.current_feature.take()?;
+        let seq = std::mem::take(&mut self.buffer);
+        self.expected_next = FIRST_CHUNK_INDEX;
+        Some((fid, seq))
+    }
+}
+
+// ============================================================================
+// Feature → bucket mapping
+// ============================================================================
+
+/// Column name of the bucket label in the mapping stream.
+const MAP_COL_BUCKET_NAME: &str = "bucket_name";
+
+/// Replace control / non-graphic characters with `_` so bucket names are safe in
+/// file paths and metadata. Mirrors `commands::helpers::sanitize_bucket_name`,
+/// which lives in the binary and is unreachable from the library.
+fn sanitize_bucket_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_control() || (!c.is_ascii_graphic() && !c.is_whitespace()) {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+/// The fully-resolved feature→bucket mapping, consumed up front from the mapping
+/// stream. Holding it whole lets us assign deterministic bucket IDs and track
+/// per-bucket completion (so a bucket's orientation baseline can be freed as soon
+/// as its last feature is processed).
+#[derive(Debug)]
+struct BucketMap {
+    /// feature_idx → assigned bucket id.
+    feature_to_bucket: std::collections::HashMap<i64, u32>,
+    /// bucket id → sanitized bucket name.
+    bucket_names: std::collections::HashMap<u32, String>,
+    /// bucket id → number of features not yet processed.
+    remaining: std::collections::HashMap<u32, u64>,
+}
+
+impl BucketMap {
+    /// Read the entire mapping stream (`feature_idx: Int64`, `bucket_name: Utf8`)
+    /// and assign bucket ids `1..=N` over the sorted unique sanitized names.
+    fn from_reader(
+        mapping: impl Iterator<Item = Result<RecordBatch, ArrowError>>,
+    ) -> RypeResult<Self> {
+        use std::collections::HashMap;
+
+        // Pass 1: feature_idx → sanitized bucket name (rejecting duplicate features).
+        let mut feature_to_name: HashMap<i64, String> = HashMap::new();
+        // Sanitized name → the raw name that produced it, to fail loud when two
+        // *distinct* raw names collapse to the same sanitized bucket (matches the
+        // CLI's validate_unique_bucket_names; silent merging would lose a bucket).
+        let mut sanitized_from: HashMap<String, String> = HashMap::new();
+        for batch in mapping {
+            let batch =
+                batch.map_err(|e| RypeError::validation(format!("mapping stream error: {e}")))?;
+            let f_idx = column_index(&batch, COL_FEATURE_IDX)?;
+            let n_idx = column_index(&batch, MAP_COL_BUCKET_NAME)?;
+            let features = batch
+                .column(f_idx)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    RypeError::validation(format!(
+                        "mapping column '{}' must be Int64, got {:?}",
+                        COL_FEATURE_IDX,
+                        batch.column(f_idx).data_type()
+                    ))
+                })?;
+            let names = BytesColumn::from_column(&batch, n_idx, MAP_COL_BUCKET_NAME)?;
+            for i in 0..batch.num_rows() {
+                if features.is_null(i) {
+                    return Err(RypeError::validation(format!(
+                        "null '{}' at mapping row {}",
+                        COL_FEATURE_IDX, i
+                    )));
+                }
+                if names.is_null(i) {
+                    return Err(RypeError::validation(format!(
+                        "null '{}' at mapping row {}",
+                        MAP_COL_BUCKET_NAME, i
+                    )));
+                }
+                let fid = features.value(i);
+                let raw = String::from_utf8_lossy(names.value(i)).into_owned();
+                let name = sanitize_bucket_name(&raw);
+                match sanitized_from.get(&name) {
+                    Some(prev) if *prev != raw => {
+                        return Err(RypeError::validation(format!(
+                            "bucket names {:?} and {:?} both sanitize to {:?}; bucket names \
+                             must be distinct after sanitization",
+                            prev, raw, name
+                        )));
+                    }
+                    None => {
+                        sanitized_from.insert(name.clone(), raw);
+                    }
+                    _ => {}
+                }
+                if feature_to_name.insert(fid, name).is_some() {
+                    return Err(RypeError::validation(format!(
+                        "feature {} appears multiple times in the bucket mapping; each \
+                         feature must map to exactly one bucket",
+                        fid
+                    )));
+                }
+            }
+        }
+
+        // Assign bucket ids 1..=N over the sorted unique names (deterministic).
+        let mut unique: Vec<&String> = feature_to_name.values().collect();
+        unique.sort_unstable();
+        unique.dedup();
+        let mut name_to_id: HashMap<&str, u32> = HashMap::with_capacity(unique.len());
+        let mut bucket_names: HashMap<u32, String> = HashMap::with_capacity(unique.len());
+        for (i, name) in unique.iter().enumerate() {
+            let id = (i + 1) as u32;
+            name_to_id.insert(name.as_str(), id);
+            bucket_names.insert(id, (*name).clone());
+        }
+
+        // Build feature→bucket and per-bucket remaining counts.
+        let mut feature_to_bucket: HashMap<i64, u32> =
+            HashMap::with_capacity(feature_to_name.len());
+        let mut remaining: HashMap<u32, u64> = HashMap::with_capacity(bucket_names.len());
+        for (fid, name) in &feature_to_name {
+            let id = name_to_id[name.as_str()];
+            feature_to_bucket.insert(*fid, id);
+            *remaining.entry(id).or_insert(0) += 1;
+        }
+
+        Ok(Self {
+            feature_to_bucket,
+            bucket_names,
+            remaining,
+        })
+    }
+
+    fn num_buckets(&self) -> u32 {
+        self.bucket_names.len() as u32
+    }
+
+    /// Bucket id for a feature; errors if the feature has no mapping entry.
+    fn bucket_of(&self, feature_idx: i64) -> RypeResult<u32> {
+        self.feature_to_bucket
+            .get(&feature_idx)
+            .copied()
+            .ok_or_else(|| {
+                RypeError::validation(format!(
+                    "feature {} in the chunk stream has no bucket mapping",
+                    feature_idx
+                ))
+            })
+    }
+
+    /// Decrement a bucket's remaining-feature count; returns `true` when it reaches
+    /// zero (the bucket is now complete).
+    fn mark_feature_done(&mut self, bucket_id: u32) -> bool {
+        match self.remaining.get_mut(&bucket_id) {
+            Some(r) => {
+                *r = r.saturating_sub(1);
+                *r == 0
+            }
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{ArrayRef, BinaryArray, Int32Array, Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    /// Build a chunk RecordBatch from (feature_idx, chunk_index, chunk_data) triples.
+    fn chunk_batch(rows: &[(i64, i32, &[u8])]) -> RecordBatch {
+        let features: Int64Array = rows.iter().map(|(f, _, _)| *f).collect();
+        let indices: Int32Array = rows.iter().map(|(_, c, _)| *c).collect();
+        let data: BinaryArray = BinaryArray::from(rows.iter().map(|(_, _, d)| *d).collect::<Vec<_>>());
+        let schema = Schema::new(vec![
+            Field::new(COL_FEATURE_IDX, DataType::Int64, false),
+            Field::new(COL_CHUNK_INDEX, DataType::Int32, false),
+            Field::new(COL_CHUNK_DATA, DataType::Binary, false),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(features) as ArrayRef,
+                Arc::new(indices) as ArrayRef,
+                Arc::new(data) as ArrayRef,
+            ],
+        )
+        .unwrap()
+    }
+
+    /// Drain a reassembler across a list of batches into completed features.
+    fn reassemble(batches: &[RecordBatch]) -> RypeResult<Vec<(i64, Vec<u8>)>> {
+        let mut r = FeatureReassembler::new();
+        let mut out = Vec::new();
+        for b in batches {
+            out.extend(r.push_batch(b)?);
+        }
+        out.extend(r.finish());
+        Ok(out)
+    }
+
+    #[test]
+    fn reassembles_chunks_in_order() {
+        let batch = chunk_batch(&[
+            (1, 0, b"ACGT"),
+            (1, 1, b"TTGG"),
+            (1, 2, b"CC"),
+            (2, 0, b"GGGG"),
+        ]);
+        let out = reassemble(&[batch]).unwrap();
+        assert_eq!(out, vec![(1, b"ACGTTTGGCC".to_vec()), (2, b"GGGG".to_vec())]);
+    }
+
+    #[test]
+    fn reassembles_feature_split_across_batches() {
+        let b1 = chunk_batch(&[(7, 0, b"AAAA"), (7, 1, b"CCCC")]);
+        let b2 = chunk_batch(&[(7, 2, b"GGGG"), (8, 0, b"TTTT")]);
+        let out = reassemble(&[b1, b2]).unwrap();
+        assert_eq!(out, vec![(7, b"AAAACCCCGGGG".to_vec()), (8, b"TTTT".to_vec())]);
+    }
+
+    #[test]
+    fn rejects_gap_in_chunk_index() {
+        // 0 then 2: missing chunk 1.
+        let batch = chunk_batch(&[(1, 0, b"AC"), (1, 2, b"GT")]);
+        let err = reassemble(&[batch]).unwrap_err();
+        assert!(err.to_string().contains("expected chunk_index 1"), "{err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_chunk_index() {
+        let batch = chunk_batch(&[(1, 0, b"AC"), (1, 0, b"GT")]);
+        let err = reassemble(&[batch]).unwrap_err();
+        assert!(err.to_string().contains("expected chunk_index 1"), "{err}");
+    }
+
+    #[test]
+    fn rejects_nonzero_first_chunk() {
+        let batch = chunk_batch(&[(1, 1, b"AC")]);
+        let err = reassemble(&[batch]).unwrap_err();
+        assert!(err.to_string().contains("first chunk_index must be 0"), "{err}");
+    }
+
+    #[test]
+    fn rejects_feature_reappearing_after_close() {
+        // feature 1, then 2, then 1 again.
+        let batch = chunk_batch(&[(1, 0, b"AC"), (2, 0, b"GG"), (1, 0, b"TT")]);
+        let err = reassemble(&[batch]).unwrap_err();
+        assert!(err.to_string().contains("reappeared"), "{err}");
+    }
+
+    #[test]
+    fn missing_column_errors() {
+        let schema = Schema::new(vec![Field::new(COL_FEATURE_IDX, DataType::Int64, false)]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(Int64Array::from(vec![1i64])) as ArrayRef],
+        )
+        .unwrap();
+        let mut r = FeatureReassembler::new();
+        let err = r.push_batch(&batch).unwrap_err();
+        assert!(err.to_string().contains("missing required column"), "{err}");
+    }
+
+    // ===== Phase 2: BucketMap =====
+
+    /// Build a mapping RecordBatch from (feature_idx, bucket_name) rows.
+    fn mapping_batch(rows: &[(i64, &str)]) -> RecordBatch {
+        let features: Int64Array = rows.iter().map(|(f, _)| *f).collect();
+        let names = StringArray::from(rows.iter().map(|(_, n)| *n).collect::<Vec<&str>>());
+        let schema = Schema::new(vec![
+            Field::new(COL_FEATURE_IDX, DataType::Int64, false),
+            Field::new(MAP_COL_BUCKET_NAME, DataType::Utf8, false),
+        ]);
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(features) as ArrayRef, Arc::new(names) as ArrayRef],
+        )
+        .unwrap()
+    }
+
+    fn bucket_map(batches: Vec<RecordBatch>) -> RypeResult<BucketMap> {
+        BucketMap::from_reader(batches.into_iter().map(Ok))
+    }
+
+    #[test]
+    fn assigns_deterministic_ids_over_sorted_names() {
+        // Two distinct names; "alpha" sorts before "zeta" → alpha=1, zeta=2.
+        let m = bucket_map(vec![mapping_batch(&[(10, "zeta"), (20, "alpha"), (30, "alpha")])])
+            .unwrap();
+        assert_eq!(m.num_buckets(), 2);
+        let alpha = m.bucket_of(20).unwrap();
+        let zeta = m.bucket_of(10).unwrap();
+        assert_eq!(alpha, 1);
+        assert_eq!(zeta, 2);
+        // Two features share "alpha".
+        assert_eq!(m.bucket_of(30).unwrap(), alpha);
+        assert_eq!(m.bucket_names[&alpha], "alpha");
+        assert_eq!(m.bucket_names[&zeta], "zeta");
+    }
+
+    #[test]
+    fn mapping_spans_multiple_batches() {
+        let m = bucket_map(vec![
+            mapping_batch(&[(1, "b")]),
+            mapping_batch(&[(2, "a"), (3, "b")]),
+        ])
+        .unwrap();
+        assert_eq!(m.num_buckets(), 2);
+        // a=1, b=2 (sorted). features 1 and 3 share b.
+        assert_eq!(m.bucket_of(2).unwrap(), 1);
+        assert_eq!(m.bucket_of(1).unwrap(), m.bucket_of(3).unwrap());
+    }
+
+    #[test]
+    fn unmapped_feature_errors() {
+        let m = bucket_map(vec![mapping_batch(&[(1, "a")])]).unwrap();
+        let err = m.bucket_of(99).unwrap_err();
+        assert!(err.to_string().contains("no bucket mapping"), "{err}");
+    }
+
+    #[test]
+    fn duplicate_feature_in_mapping_errors() {
+        let err = bucket_map(vec![mapping_batch(&[(1, "a"), (1, "b")])]).unwrap_err();
+        assert!(err.to_string().contains("multiple times"), "{err}");
+    }
+
+    #[test]
+    fn completion_counter_signals_on_last_feature() {
+        let mut m = bucket_map(vec![mapping_batch(&[(10, "a"), (20, "a"), (30, "b")])]).unwrap();
+        let a = m.bucket_of(10).unwrap();
+        let b = m.bucket_of(30).unwrap();
+        // bucket a has 2 features.
+        assert!(!m.mark_feature_done(a), "first of two should not complete");
+        assert!(m.mark_feature_done(a), "second of two should complete");
+        // bucket b has 1 feature.
+        assert!(m.mark_feature_done(b), "single feature completes immediately");
+    }
+
+    #[test]
+    fn sanitizes_bucket_names() {
+        let m = bucket_map(vec![mapping_batch(&[(1, "weird\tname")])]).unwrap();
+        let id = m.bucket_of(1).unwrap();
+        assert_eq!(m.bucket_names[&id], "weird_name");
+    }
+
+    #[test]
+    fn distinct_names_colliding_after_sanitize_error() {
+        // "n\u{1}" and "n\u{2}" both sanitize to "n_": distinct buckets that would
+        // silently merge. Must fail loud (CLI parity).
+        let err = bucket_map(vec![mapping_batch(&[(1, "n\u{1}"), (2, "n\u{2}")])]).unwrap_err();
+        assert!(err.to_string().contains("sanitize"), "{err}");
+    }
+
+    #[test]
+    fn null_mapping_values_error() {
+        // Null bucket_name in the mapping must fail loud.
+        let features = Int64Array::from(vec![1i64]);
+        let names = StringArray::from(vec![None as Option<&str>]);
+        let schema = Schema::new(vec![
+            Field::new(COL_FEATURE_IDX, DataType::Int64, false),
+            Field::new(MAP_COL_BUCKET_NAME, DataType::Utf8, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(features) as ArrayRef, Arc::new(names) as ArrayRef],
+        )
+        .unwrap();
+        let err = BucketMap::from_reader(std::iter::once(Ok(batch))).unwrap_err();
+        assert!(err.to_string().contains("null"), "{err}");
+    }
+
+    // ===== Phase 3: end-to-end build (orient off) =====
+
+    use crate::parquet_index::merge::load_all_minimizers;
+    use crate::{extract_into, MinimizerWorkspace, ShardedInvertedIndex};
+    use std::collections::HashSet;
+
+    /// Deterministic pseudo-DNA of length `n` (ACGT only), varied by `seed`.
+    fn make_dna(n: usize, seed: usize) -> Vec<u8> {
+        let alpha = b"ACGT";
+        (0..n)
+            .map(|i| alpha[(i * 7 + i / 3 + seed * 3 + (i % 5)) % 4])
+            .collect()
+    }
+
+    /// One batch holding all of `seq`'s chunks for `feature`, split every `chunk_len`.
+    fn single_feature_chunk_batch(feature: i64, seq: &[u8], chunk_len: usize) -> RecordBatch {
+        let rows: Vec<(i64, i32, &[u8])> = seq
+            .chunks(chunk_len)
+            .enumerate()
+            .map(|(i, p)| (feature, i as i32, p))
+            .collect();
+        chunk_batch(&rows)
+    }
+
+    fn reference_minimizers(seq: &[u8], k: usize, w: usize, salt: u64) -> HashSet<u64> {
+        let mut ws = MinimizerWorkspace::new();
+        extract_into(seq, k, w, salt, &mut ws);
+        ws.buffer.iter().copied().collect()
+    }
+
+    /// Reverse-complement of an ACGT sequence.
+    fn revcomp(seq: &[u8]) -> Vec<u8> {
+        seq.iter()
+            .rev()
+            .map(|&b| match b {
+                b'A' => b'T',
+                b'T' => b'A',
+                b'C' => b'G',
+                b'G' => b'C',
+                other => other,
+            })
+            .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build(
+        out: &std::path::Path,
+        chunks: Vec<RecordBatch>,
+        mapping: Vec<RecordBatch>,
+        k: usize,
+        w: usize,
+        salt: u64,
+        orient: bool,
+    ) -> RypeResult<ArrowBuildStats> {
+        build_index_from_arrow(
+            out,
+            chunks.into_iter().map(Ok),
+            mapping.into_iter().map(Ok),
+            k,
+            w,
+            salt,
+            orient,
+            Some(64 << 20),
+            None,
+        )
+    }
+
+    #[test]
+    fn arrow_build_minimizers_match_unchunked_reference() {
+        // The crux: a chunked build must reproduce the minimizers of the un-chunked
+        // sequence exactly — proving reassembly loses nothing across chunk boundaries.
+        let seq = make_dna(512, 1);
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+
+        let chunks = vec![single_feature_chunk_batch(1, &seq, 64)];
+        let mapping = vec![mapping_batch(&[(1, "genome1")])];
+        let stats = build_index_from_arrow(
+            &out,
+            chunks.into_iter().map(Ok),
+            mapping.into_iter().map(Ok),
+            k,
+            w,
+            salt,
+            false,
+            Some(64 << 20),
+            None,
+        )
+        .unwrap();
+        assert_eq!(stats.num_buckets, 1);
+        assert_eq!(stats.num_features, 1);
+
+        let idx = ShardedInvertedIndex::open(&out).unwrap();
+        let got = load_all_minimizers(&idx).unwrap();
+        let want = reference_minimizers(&seq, k, w, salt);
+        assert!(!want.is_empty(), "test sequence should yield minimizers");
+        assert_eq!(
+            got, want,
+            "chunked build must reproduce un-chunked minimizers exactly"
+        );
+    }
+
+    #[test]
+    fn arrow_build_multi_bucket_opens() {
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let s1 = make_dna(200, 1);
+        let s2 = make_dna(180, 2);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+
+        let chunks = vec![
+            single_feature_chunk_batch(1, &s1, 64),
+            single_feature_chunk_batch(2, &s2, 64),
+        ];
+        let mapping = vec![mapping_batch(&[(1, "g1"), (2, "g2")])];
+        let stats = build_index_from_arrow(
+            &out,
+            chunks.into_iter().map(Ok),
+            mapping.into_iter().map(Ok),
+            k,
+            w,
+            salt,
+            false,
+            Some(64 << 20),
+            None,
+        )
+        .unwrap();
+        assert_eq!(stats.num_buckets, 2);
+        assert_eq!(stats.num_features, 2);
+
+        let idx = ShardedInvertedIndex::open(&out).unwrap();
+        assert!(idx.total_minimizers() > 0);
+    }
+
+    #[test]
+    fn source_labels_use_feature_idx_delim_form() {
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+        let chunks = vec![
+            single_feature_chunk_batch(10, &make_dna(120, 1), 64),
+            single_feature_chunk_batch(20, &make_dna(120, 2), 64),
+        ];
+        // Both features in one bucket "g".
+        let mapping = vec![mapping_batch(&[(10, "g"), (20, "g")])];
+        build_index_from_arrow(
+            &out,
+            chunks.into_iter().map(Ok),
+            mapping.into_iter().map(Ok),
+            k,
+            w,
+            salt,
+            false,
+            Some(64 << 20),
+            None,
+        )
+        .unwrap();
+
+        let (_names, sources, _stats) =
+            crate::parquet_index::read_buckets_parquet(&out).unwrap();
+        let bucket_sources = sources.values().next().unwrap();
+        let mut got: Vec<&String> = bucket_sources.iter().collect();
+        got.sort();
+        assert_eq!(got, vec![&"feature_idx::10".to_string(), &"feature_idx::20".to_string()]);
+    }
+
+    #[test]
+    fn invalid_k_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+        let chunks = vec![single_feature_chunk_batch(1, &make_dna(64, 1), 32)];
+        let mapping = vec![mapping_batch(&[(1, "g")])];
+        let err = build_index_from_arrow(
+            &out,
+            chunks.into_iter().map(Ok),
+            mapping.into_iter().map(Ok),
+            20, // invalid: must be 16, 32, or 64
+            5,
+            0,
+            false,
+            Some(64 << 20),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("16, 32, or 64"), "{err}");
+    }
+
+    #[test]
+    fn orientation_flips_rc_to_baseline() {
+        // Bucket "g": feature 1 = S (baseline, forward), feature 2 = revcomp(S).
+        // With orient on, feature 2 is flipped back, so the bucket's minimizer set
+        // equals S's forward set. With orient off it does NOT (RC adds new minimizers).
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let s = make_dna(300, 1);
+        let rc = revcomp(&s);
+        let want = reference_minimizers(&s, k, w, salt);
+        assert!(!want.is_empty());
+
+        let dir = tempfile::tempdir().unwrap();
+
+        let out_on = dir.path().join("on.ryxdi");
+        build(
+            &out_on,
+            vec![
+                single_feature_chunk_batch(1, &s, 64),
+                single_feature_chunk_batch(2, &rc, 64),
+            ],
+            vec![mapping_batch(&[(1, "g"), (2, "g")])],
+            k,
+            w,
+            salt,
+            true,
+        )
+        .unwrap();
+        let got_on = load_all_minimizers(&ShardedInvertedIndex::open(&out_on).unwrap()).unwrap();
+        assert_eq!(got_on, want, "orientation should flip RC feature back to baseline");
+
+        let out_off = dir.path().join("off.ryxdi");
+        build(
+            &out_off,
+            vec![
+                single_feature_chunk_batch(1, &s, 64),
+                single_feature_chunk_batch(2, &rc, 64),
+            ],
+            vec![mapping_batch(&[(1, "g"), (2, "g")])],
+            k,
+            w,
+            salt,
+            false,
+        )
+        .unwrap();
+        let got_off = load_all_minimizers(&ShardedInvertedIndex::open(&out_off).unwrap()).unwrap();
+        assert!(
+            got_off.len() > got_on.len(),
+            "without orientation the RC feature adds distinct minimizers (on={}, off={})",
+            got_on.len(),
+            got_off.len()
+        );
+    }
+
+    #[test]
+    fn orientation_baseline_survives_interleaved_buckets() {
+        // Stream order interleaves buckets: g1(f1=S1), g2(f2=S2), g1(f3=revcomp(S1)).
+        // g1's baseline must still be alive when f3 arrives (freed only after f3),
+        // so f3 flips back to S1. Premature freeing would leave f3 forward (RC) and
+        // change the union.
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let s1 = make_dna(300, 1);
+        let s2 = make_dna(280, 2);
+        let mut want = reference_minimizers(&s1, k, w, salt);
+        want.extend(reference_minimizers(&s2, k, w, salt));
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("idx.ryxdi");
+        build(
+            &out,
+            vec![
+                single_feature_chunk_batch(1, &s1, 64),
+                single_feature_chunk_batch(2, &s2, 64),
+                single_feature_chunk_batch(3, &revcomp(&s1), 64),
+            ],
+            vec![mapping_batch(&[(1, "g1"), (2, "g2"), (3, "g1")])],
+            k,
+            w,
+            salt,
+            true,
+        )
+        .unwrap();
+        let got = load_all_minimizers(&ShardedInvertedIndex::open(&out).unwrap()).unwrap();
+        assert_eq!(got, want, "interleaved orientation must keep g1's baseline live for f3");
+    }
+
+    #[test]
+    fn parallel_batching_is_invariant_to_batch_size() {
+        // The built index must be identical whether features are extracted one-per-batch
+        // (forces cross-batch baseline persistence) or all in one batch (forces the
+        // within-batch seed/seeded classification). Mix of buckets, interleaving, and an
+        // RC feature that must orient back to its bucket's baseline.
+        let (k, w, salt) = (16usize, 5usize, 0x5555_5555_5555_5555u64);
+        let s1 = make_dna(300, 1);
+        let seqs: Vec<(i64, &str, Vec<u8>)> = vec![
+            (1, "g1", s1.clone()),
+            (2, "g2", make_dna(280, 2)),
+            (3, "g1", revcomp(&s1)), // RC of feature 1 → orients back under g1's baseline
+            (4, "g3", make_dna(260, 4)),
+            (5, "g2", make_dna(290, 5)),
+            (6, "g1", make_dna(310, 6)),
+        ];
+
+        let build_with = |batch_target_bytes: usize| -> (HashSet<u64>, ArrowBuildStats) {
+            let dir = tempfile::tempdir().unwrap();
+            let out = dir.path().join("idx.ryxdi");
+            let chunks: Vec<RecordBatch> = seqs
+                .iter()
+                .map(|(f, _, s)| single_feature_chunk_batch(*f, s, 64))
+                .collect();
+            let map_rows: Vec<(i64, &str)> = seqs.iter().map(|(f, b, _)| (*f, *b)).collect();
+            let mapping = vec![mapping_batch(&map_rows)];
+            let stats = build_index_from_arrow_inner(
+                &out,
+                chunks.into_iter().map(Ok),
+                mapping.into_iter().map(Ok),
+                k,
+                w,
+                salt,
+                true, // orient
+                64 << 20,
+                batch_target_bytes,
+                None,
+            )
+            .unwrap();
+            let got = load_all_minimizers(&ShardedInvertedIndex::open(&out).unwrap()).unwrap();
+            (got, stats)
+        };
+
+        let (one_per_batch, stats_small) = build_with(1); // each feature flushes alone
+        let (single_batch, stats_big) = build_with(1 << 30); // all features in one batch
+        assert_eq!(
+            one_per_batch, single_batch,
+            "minimizer set must not depend on batch size"
+        );
+        assert_eq!(stats_small.num_features, 6);
+        assert_eq!(stats_small.num_buckets, 3);
+        assert_eq!(stats_small.num_features, stats_big.num_features);
+        assert_eq!(stats_small.num_buckets, stats_big.num_buckets);
+    }
+}

--- a/src/indices/parquet/mod.rs
+++ b/src/indices/parquet/mod.rs
@@ -14,6 +14,7 @@
 //! Note: The main index uses the single-file format (.ryidx) only.
 //! Parquet format is only used for the inverted index.
 
+mod arrow_build;
 mod buckets;
 mod manifest;
 pub mod merge;
@@ -41,6 +42,7 @@ pub mod files {
 }
 
 // Re-export public types from submodules
+pub use arrow_build::{build_index_from_arrow, ArrowBuildStats};
 pub use buckets::{read_buckets_parquet, write_buckets_parquet};
 pub use manifest::{
     create_index_directory, is_parquet_index, BucketData, BucketMetadata, InvertedManifest,


### PR DESCRIPTION
## Summary

Adds `rype_index_build_from_arrow`, a C/FFI entry point that builds a `.ryxdi` index by **streaming chunked genome sequences over Arrow** — the shape produced by a DuckDB/DuckLake pipeline (`feature_idx`, `chunk_index`, `chunk_data`) plus a small `feature_idx → bucket_name` mapping. Previously the only build paths (`from-config`, `create`) were binary-only and read FASTA files / TOML; there was no way to build an index from C.

## What's here

**Core builder** — `src/indices/parquet/arrow_build.rs` (in the library, so it's unit-testable without the `arrow-ffi` feature):
- **Reassembles** each feature's full sequence from its chunks in `chunk_index` order, failing loud on gaps / duplicates / regressions / reappearance — so minimizers are correct across the ~64 KB chunk boundaries.
- Consumes the `feature_idx → bucket_name` mapping **up front**, assigns bucket IDs over the sorted unique sanitized names, and tracks per-bucket completion to **free orientation baselines** the moment a bucket finishes.
- Streams minimizers into a `ShardAccumulator` and finalizes by mirroring the existing multi-bucket streaming tail (`write_buckets_parquet` + `ParquetManifest`, `has_overlapping_shards = true`).
- **Orientation** support (per-bucket fixed baseline + `choose_orientation_sampled`) and **parallel**, byte-bounded batch extraction via rayon. The resulting minimizer set and orientation decisions are invariant to how features are grouped into batches.

**FFI + docs:**
- `rype_index_build_from_arrow(output_path, chunk_stream, mapping_stream, k, w, salt, orient, max_memory_bytes)` in `src/c_api.rs` (gated `arrow-ffi`), consuming two `FFI_ArrowArrayStream` pointers.
- Prototype, both input schemas, and ownership / partial-write-on-error caveats in `rype.h`.
- `examples/pyarrow_build_example.py` + README entry.

## Testing

- 23 `arrow_build` unit tests + 3 FFI tests. Correctness anchors: a **lossless-reassembly equivalence proof** (chunked build's minimizer set == un-chunked `extract_into` reference) and a **batch-size-invariance** test (one-feature-per-batch vs single-batch produce identical indices).
- Full suite green (`cargo test --features arrow-ffi --lib` → 540 passed); `cargo clippy --all-features -- -D warnings` clean.
- **End-to-end on 200 MB of synthetic genomes**: the Arrow path reproduces the `from-config` index **exactly** (identical 8,476,435 minimizers); rayon extraction runs multi-core; peak RSS bounded. (Real WoL2 perf-data was unavailable in the dev environment — synthetic stand-in used, noted in the plan.)

## Notes for reviewers

- Source labels are `feature_idx::<id>` (this data model has no file path); `rype index bucket-source-detail` stays well-formed.
- Single-bucket Arrow builds leave `has_overlapping_shards = true` (no consolidation), matching the multi-bucket path — correct, slightly less query-time-optimal than the CLI's single-bucket consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)