### PR TITLE
perf(shard): parallelize the accumulator flush sort

### DIFF
--- a/src/indices/parquet/streaming.rs
+++ b/src/indices/parquet/streaming.rs
@@ -813,8 +813,13 @@ impl ShardAccumulator {
             )));
         }
 
-        // Sort entries by (minimizer, bucket_id) and remove duplicates
-        self.entries.sort_unstable();
+        // Sort entries by (minimizer, bucket_id) and remove duplicates. This flush
+        // buffer holds up to ~max_shard_bytes/16 entries (≈1B at a 30 GiB build), and
+        // the sort runs on the serial flush path between parallel extraction bursts, so
+        // it is one of the build's larger single-threaded costs. par_sort_unstable
+        // parallelizes it across the rayon pool (with a sequential fallback for small
+        // buffers); the ordering — and therefore the subsequent dedup — is identical.
+        self.entries.par_sort_unstable();
         self.entries.dedup();
 
         // Extract min/max for shard info (after dedup for correct count)


### PR DESCRIPTION
## What

`ShardAccumulator::flush_shard` sorted its flush buffer with single-threaded `sort_unstable`. That sort runs on the **serial** flush path between the parallel extraction bursts, and at a large build the buffer is huge (flush threshold = `max_shard_bytes`, ≈ `max_memory/2` → ~1 B `(minimizer, bucket_id)` entries at a 30 GiB build), sorted several times over a build. It's one of the larger single-threaded gaps — the `rype_index_create` Arrow build path was measured peaking at only ~2.7 of 8 cores, with the rest of the time in serial phases like this one.

One-line change: `sort_unstable()` → `par_sort_unstable()` (rayon is already a dependency; it falls back to sequential for small buffers).

## Correctness

The sort order is identical, so the following `dedup()` and the written shard contents are unchanged. All **459 lib tests pass unchanged** (including the accumulator and streaming-consolidation tests that assert shard contents), and the benchmark below clone-and-compares to assert `par_sort_unstable` yields byte-identical ordering.

## Performance (200 M `(u64,u32)` entries, representative of a flush buffer)

| threads | `sort_unstable` | `par_sort_unstable` | speedup |
|--------:|----------------:|--------------------:|--------:|
| 8       | 4.82 s          | 1.42 s              | **3.39×** |
| 32      | 4.82 s          | 1.20 s              | 4.01× |
| 8 (1 M buffer) | 16.3 ms  | 3.96 ms             | 4.11× (no small-buffer regression) |

End-to-end build improvement scales with how much of a given build is flush-sort-bound — larger at higher `max_memory` / bigger flush buffers. This is the cheapest of the build-parallelization levers; the serial DuckDB feed and (at low memory) the consolidation merge remain as separate, larger follow-ups if build wall-time needs more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
