### PR TITLE
deps: update arrow and parquet from 57 to 59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ log = "0.4"
 env_logger = "0.11"
 zstd = "0.13"  # Compression for inverted index
 flate2 = "1.1.8"  # Gzip compression for output
-parquet = { version = "57", default-features = false, features = ["zstd", "snap", "arrow"] }
+parquet = { version = "59", default-features = false, features = ["zstd", "snap", "arrow"] }
 bytes = "1.5"
-arrow = { version = "57", default-features = false }
+arrow = { version = "59", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/src/indices/parquet/options.rs
+++ b/src/indices/parquet/options.rs
@@ -152,7 +152,7 @@ impl ParquetWriteOptions {
             .set_writer_version(WriterVersion::PARQUET_2_0)
             .set_compression(compression)
             .set_statistics_enabled(statistics)
-            .set_max_row_group_size(self.row_group_size)
+            .set_max_row_group_row_count(Some(self.row_group_size))
             // Minimizer column: delta encoding, no dictionary
             .set_column_encoding(minimizer_col.clone(), Encoding::DELTA_BINARY_PACKED)
             .set_column_dictionary_enabled(minimizer_col.clone(), false)
@@ -168,10 +168,10 @@ impl ParquetWriteOptions {
             builder = builder
                 .set_column_bloom_filter_enabled(minimizer_col.clone(), true)
                 .set_column_bloom_filter_fpp(minimizer_col.clone(), self.bloom_filter_fpp)
-                .set_column_bloom_filter_ndv(minimizer_col, ndv)
+                .set_column_bloom_filter_max_ndv(minimizer_col, ndv)
                 .set_column_bloom_filter_enabled(bucket_id_col.clone(), true)
                 .set_column_bloom_filter_fpp(bucket_id_col.clone(), self.bloom_filter_fpp)
-                .set_column_bloom_filter_ndv(bucket_id_col, ndv);
+                .set_column_bloom_filter_max_ndv(bucket_id_col, ndv);
         }
 
         builder.build()


### PR DESCRIPTION
Bumps **arrow** and **parquet** together from 57 to 59.

### Why a combined PR
`arrow` and `parquet` are lockstep crates — `parquet`'s `arrow` feature pulls in a matching `arrow` version. Dependabot opened them as **separate** PRs (#15 arrow, #14 parquet), so each one leaves the other pinned at 57, producing two incompatible `arrow` versions in the tree and a compile failure. Neither can pass CI alone; they must move together. This PR supersedes #14 and #15.

### Changes
- `Cargo.toml`: `arrow` 57→59, `parquet` 57→59
- `src/indices/parquet/options.rs`: migrate deprecated `WriterProperties` APIs surfaced by the upgrade:
  - `set_max_row_group_size(x)` → `set_max_row_group_row_count(Some(x))` — note the signature changed from `usize` to `Option<usize>`, so this is **not** a pure rename
  - `set_column_bloom_filter_ndv` → `set_column_bloom_filter_max_ndv` (×2)

Behavior is unchanged.

### Verified locally (all CI gates)
`cargo check` (native + `wasm32-unknown-emscripten`), `clippy --all-features -D warnings`, `cargo doc -Dwarnings`, `cargo fmt --check`, and the full `cargo test --all-features` + no-default-features lib suite — all pass, ~900 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)